### PR TITLE
Fix Tanimoto bug

### DIFF
--- a/duvida/autoclass.py
+++ b/duvida/autoclass.py
@@ -6,7 +6,7 @@ from carabiner import print_err
 
 from .checkpoint_utils import load_checkpoint_file
 try:
-    from .torch import TorchMLPModelBox
+    from .torch.modelbox import *
 except ImportError as e:
     print_err(e)
     raise ImportError(

--- a/duvida/base/data.py
+++ b/duvida/base/data.py
@@ -581,11 +581,11 @@ class ChemMixinBase(DataMixinBase):
         >>> out[ChemMixinBase.smiles_column]
         ['CCC', 'CCO']
         >>> d1 = {"struc": ["CCC"]}  # singleton batch
-        >>> out1 = CMB.preprocess_data(d1, "struc", ChemMixinBase.smiles_column)
+        >>> out1 = ChemMixinBase.preprocess_data(d1, "struc", ChemMixinBase.smiles_column)
         >>> out1[ChemMixinBase.smiles_column]  # returns list
         ['CCC']
         >>> d2 = {"struc": "CCC"}  # non-batched map
-        >>> out2 = CMB.preprocess_data(d2, "struc", ChemMixinBase.smiles_column)
+        >>> out2 = ChemMixinBase.preprocess_data(d2, "struc", ChemMixinBase.smiles_column)
         >>> out2[ChemMixinBase.smiles_column]  # still returns list
         ['CCC']
         

--- a/duvida/base/information.py
+++ b/duvida/base/information.py
@@ -311,8 +311,6 @@ class DoubtMixinBase(ABC):
             preprocessing_args = {}
         if training_dataset is None:  
             dataset = self._check_training_data()
-        from carabiner import print_err
-        print_err(preprocessing_args)
 
         if hasattr(self, "_prepare_data"):
             candidates = self._prepare_data(

--- a/duvida/base/modelboxes.py
+++ b/duvida/base/modelboxes.py
@@ -101,7 +101,6 @@ class ModelBoxBase(DataMixinBase, DoubtMixinBase, ABC):
                 cache=cache,
                 **preprocessing_args,
             )
-        print_err(dataset, dataset.format)
         essential_keys = set([self._in_key, self._out_key])
         missing_keys = sorted(essential_keys - set(dataset.column_names))
         if len(missing_keys) > 0:

--- a/duvida/torch/modelbox/data.py
+++ b/duvida/torch/modelbox/data.py
@@ -48,13 +48,12 @@ class TorchChemMixin(ChemMixinBase, DataMixin):
 
     @staticmethod
     def _get_max_sim(
-        q: ArrayLike, 
+        query: ArrayLike, 
         references: ArrayLike,
         aggregator: Callable[[ArrayLike], float] = torch.max
     ) -> Array:
-        a_n_b = torch.sum(q.unsqueeze(0) * references, dim=-1, keepdim=True)
-        sum_q = torch.sum(q)
-        similarities = a_n_b / (sum_q + torch.sum(references, dim=-1) - torch.sum(a_n_b, dim=-1)).unsqueeze(-1)
+        a_n_b = torch.sum(query.unsqueeze(0) * references, dim=-1, keepdim=True)
+        similarities = a_n_b / (torch.sum(query) + torch.sum(references, dim=-1) - torch.sum(a_n_b, dim=-1)).unsqueeze(-1)
         return aggregator(similarities)
 
     @staticmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "duvida"
-version = "0.0.1"
+version = "0.0.1.post1"
 authors = [
   { name="Eachan Johnson", email="eachan.johnson@crick.ac.uk" },
 ]

--- a/test/scripts/train.sh
+++ b/test/scripts/train.sh
@@ -31,6 +31,7 @@ do
             --output "$class-$i" \
             --cache test/outputs/cache \
             --epochs 2 \
+            -z 10 \
             --learning-rate 1e-5 \
             --descriptors \
             --fp
@@ -44,10 +45,10 @@ do
             --end $STOP \
             --variance \
             --tanimoto \
-            --doubtscore \
-            --information-sensitivity \
             --optimality \
             -y clogp \
+            --prefix test/outputs/models \
+            --cache test/outputs/cache \
             --output "$outfile"
         if [ ! "$(cat "$outfile" | wc -l)" -eq $(( $STOP - $START + 1 )) ]
         then

--- a/test/scripts/train.sh
+++ b/test/scripts/train.sh
@@ -27,8 +27,7 @@ do
             -c test/outputs/hyperopt.json \
             -k "$class" \
             -i $i \
-            --prefix test/outputs/models \
-            --output "$class-$i" \
+            --output "test/outputs/models/$class-$i" \
             --cache test/outputs/cache \
             --epochs 2 \
             -z 10 \
@@ -45,9 +44,9 @@ do
             --end $STOP \
             --variance \
             --tanimoto \
+            --doubtscore \
             --optimality \
             -y clogp \
-            --prefix test/outputs/models \
             --cache test/outputs/cache \
             --output "$outfile"
         if [ ! "$(cat "$outfile" | wc -l)" -eq $(( $STOP - $START + 1 )) ]


### PR DESCRIPTION
There was a bug where calling `.tanimoto_nn()` would give the same value for every compound. This was because the preprocessing step of cleaning SMILES strings was producing a list of lists instead of a list of strings. The sub-lists were not valid SMILES, therefore producing the same error fingerprint (in `schemist`, this is a vector of -1s).

Bug is now fixed.