### PR TITLE
Fixes June 2025

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -36,10 +36,13 @@ jobs:
     - name: Test with pytest
       run: |
         export JAX_PLATFORM_NAME=cpu
+        # run doctests as individual packages
         pytest duvida/base --doctest-modules
         pytest duvida/stateless --doctest-modules
         pytest duvida/torch --doctest-modules
         pytest duvida/utils --doctest-modules
+        # run other tests
+        pytest test/test_evaluation.py
     - name: Test CLI train/test
       run: |
         bash test/scripts/train.sh

--- a/duvida/base/data.py
+++ b/duvida/base/data.py
@@ -463,6 +463,7 @@ class DataMixinBase(ABC):
             concat_label = [f.output_column for f in featurizers]
         processed_dataset = (
             input_dataset
+            .with_format(None)  # guard against tensors
             .map(
                 self._concat_features,
                 fn_kwargs={

--- a/duvida/base/evaluation.py
+++ b/duvida/base/evaluation.py
@@ -87,7 +87,7 @@ def rmse(x, y):
     >>> pred = np.array([1.0, 2.0, 3.0])
     >>> truth = np.array([1.0, 2.0, 4.0])
     >>> np.allclose(rmse(pred, truth), np.sqrt(((pred - truth) ** 2).mean()))
-    1.2909944487358056
+    True
 
     """
 

--- a/duvida/base/evaluation.py
+++ b/duvida/base/evaluation.py
@@ -1,21 +1,114 @@
 """Utilities for evaluating predictions."""
 
+from typing import Callable, Tuple
+
 import numpy as np
+from numpy.typing import ArrayLike
 import scipy
+
+def _normalize_dims(
+    x: ArrayLike, 
+    y: ArrayLike,
+    broadcast: bool = False,
+    aggfun: Callable = np.mean
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Normalize prediction dimensions.
+
+    If `x` has one extra dimension compared to `y` and their leading
+    dimensions match exactly, `x` is assumed to be an ensemble of
+    predictions and the mean across its last axis is used. Otherwise the
+    function ensures that `x` and `y` are broadcastable. and raises a
+    ``ValueError`` if they are not.
+
+    Parameters
+    ==========
+    x : ArrayLike
+        Prediction array.
+    y : ArrayLike
+        Ground truth array.
+
+    Returns
+    =======
+    Tuple[numpy.ndarray, numpy.ndarray]
+        Possibly averaged `x` and original `y`.
+
+    Raises
+    ======
+    ValueError
+        If `x` and `y` are not broadcastable.
+    
+    """
+
+    x, y = np.asarray(x), np.asarray(y)
+
+    if x.shape[:-1] != y.shape[:(x.ndim - 1)]:
+        raise ValueError(
+            f"Leading dimensions of x and y (shapes {x.shape} and {y.shape}) are not compatible!"
+        )   
+
+    if x.ndim == y.ndim + 1:
+        x = aggfun(x, axis=-1)
+    elif x.ndim == y.ndim and y.shape[-1] == 1:
+        x = aggfun(x, axis=-1, keepdims=True)
+
+    try:
+        b = np.broadcast(x, y)
+    except ValueError:
+        raise ValueError(
+            f"Shapes {x.shape} and {y.shape} are not broadcastable!"
+        )
+
+    if broadcast:
+        bshape = b.shape
+        x, y = (np.broadcast_to(v, bshape).ravel() for v in (x, y))
+
+    return x, y
 
 
 def rmse(x, y):
-    return np.mean(np.abs(np.mean(x, axis=-1, keepdims=True) - y))
+    """Root mean square error.
+
+    Parameters
+    ----------
+    x : numpy.ndarray
+        Predicted values. If predictions are provided as an ensemble, the mean
+        across the last axis is used.
+    y : numpy.ndarray
+        Ground truth values.
+
+    Returns
+    -------
+    float
+        The RMSE between ``x`` and ``y``.
+    
+    Examples
+    --------
+    >>> import numpy as np
+    >>> pred = np.array([1.0, 2.0, 3.0])
+    >>> truth = np.array([1.0, 2.0, 4.0])
+    >>> np.allclose(rmse(pred, truth), np.sqrt(((pred - truth) ** 2).mean()))
+    1.2909944487358056
+
+    """
+
+    x, y = _normalize_dims(x, y)
+    return np.sqrt(np.mean(np.square(x - y)))
+
+
+def mae(x, y):
+    x, y = _normalize_dims(x, y)
+    return np.mean(np.abs(x - y))
 
 
 def pearson_r(x, y):
-    corr = np.corrcoef(np.mean(x, axis=-1, keepdims=True), y, rowvar=False)
-    return np.diag(corr, k=1).flatten()[0]
+    x, y = _normalize_dims(x, y, broadcast=True)
+    return  np.corrcoef(x, y)[0, 1]
 
 
 def spearman_r(x, y):
+    x, y = _normalize_dims(x, y, broadcast=True)
     return scipy.stats.spearmanr(
-        np.mean(x, axis=-1).flatten(), 
-        y.flatten(), 
+        x, 
+        y, 
         nan_policy="omit",
     ).statistic

--- a/duvida/base/modelboxes.py
+++ b/duvida/base/modelboxes.py
@@ -321,7 +321,7 @@ class ModelBoxBase(DataMixinBase, DoubtMixinBase, ABC):
                 "pearson_r": pearson_r, 
                 "spearman_rho": spearman_r,
             }
-        predictions = predictions.with_format("numpy")
+        predictions = predictions.with_format(None)
         y_vals = predictions[self._out_key]
         preds = predictions[eval_prediction_col]
         # if len(y_vals.shape) == 1 and len(preds.shape) == 2:
@@ -462,9 +462,9 @@ class FingerprintModelBoxBase(ChemMixinBase, ModelBoxWithVarianceBase):
             structure_column = self._default_preprocessing_args["structure_column"]
         if input_representation is None:
             input_representation = self._default_preprocessing_args["input_representation"]
-        _extra_cols_to_keep=(
-                [structure_column] + kwargs.pop("_extra_cols_to_keep", [])
-            )
+        _extra_cols_to_keep = (
+            [structure_column] + kwargs.pop("_extra_cols_to_keep", [])
+        )
         return super().predict(
             **kwargs, 
             structure_column=structure_column,

--- a/duvida/base/modelboxes.py
+++ b/duvida/base/modelboxes.py
@@ -321,7 +321,7 @@ class ModelBoxBase(DataMixinBase, DoubtMixinBase, ABC):
                 "pearson_r": pearson_r, 
                 "spearman_rho": spearman_r,
             }
-        predictions = predictions.with_format(None)
+        predictions = predictions.with_format("numpy")
         y_vals = predictions[self._out_key]
         preds = predictions[eval_prediction_col]
         # if len(y_vals.shape) == 1 and len(preds.shape) == 2:

--- a/duvida/cli.py
+++ b/duvida/cli.py
@@ -12,20 +12,16 @@ from carabiner.cliutils import clicommand, CLIOption, CLICommand, CLIApp
 
 from . import __version__
 from .checkpoint_utils import _load_json, save_json
+from .utils.package_data import _get_data_path
 
-_data_root = os.path.join(
-    os.path.dirname(__file__), 
-    "data",
-)
-modelbox_name_file = os.path.join(_data_root, "modelbox-names.json")
+
+cache_dir, modelbox_name_file = _get_data_path("modelbox-names.json")
 if not os.path.exists(modelbox_name_file):
     from .autoclass import AutoModelBox
     from .base.modelbox_registry import DEFAULT_MODELBOX, MODELBOX_NAMES
-    if not os.path.exists(_data_root):
-        os.makedirs(_data_root)
     save_json([DEFAULT_MODELBOX, MODELBOX_NAMES], modelbox_name_file)
 else:
-    DEFAULT_MODELBOX, MODELBOX_NAMES = _load_json(_data_root, "modelbox-names.json")
+    DEFAULT_MODELBOX, MODELBOX_NAMES = _load_json(cache_dir, os.path.basename(modelbox_name_file))
 
 _LR_DEFAULT: float = .01
 

--- a/duvida/utils/package_data.py
+++ b/duvida/utils/package_data.py
@@ -1,0 +1,23 @@
+"""Tools for loading and writing reusable package data."""
+
+import os
+
+DUVIDA_CACHE = "DUVIDA_CACHE"
+DEFAULT_CACHE = os.path.join("~", ".cache", "duvida", "data")
+
+def _get_data_path(
+    filename: str, 
+    env_key: str = DUVIDA_CACHE,
+    default: str = DEFAULT_CACHE
+) -> str:
+    """Returns the path to a writable version of a package data file.
+    
+    Copies it from the package resources if not present.
+
+    """
+    cache_dir = os.environ.get(
+        env_key, 
+        os.path.expanduser(default),
+    )
+    os.makedirs(cache_dir, exist_ok=True)
+    return cache_dir, os.path.join(cache_dir, filename)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -13,4 +13,4 @@ def reload_package():
     # delete all modules from package
     loaded_package_modules = [key for key, value in sys.modules.items() if "duvida" in str(value)]
     for key in loaded_package_modules:
-        del sys.modules[key]
+        pass #del sys.modules[key]

--- a/test/test_evaluation.py
+++ b/test/test_evaluation.py
@@ -1,0 +1,39 @@
+import numpy as np
+import pytest
+from duvida.base.evaluation import rmse, pearson_r, spearman_r
+
+
+def test_rmse_simple():
+    pred = [1., 2., 3.]
+    truth = [1., 2., 4.]
+    assert rmse(pred, truth) == pytest.approx(np.sqrt(((np.asarray(pred) - np.asarray(truth)) ** 2).mean()))
+
+
+def test_rmse_ensemble():
+    pred = [[1., 2.], [2., 3.], [3., 4.]]
+    truth = [1., 2., 4.]
+    expected = np.sqrt(((np.asarray(pred).mean(axis=-1) - np.asarray(truth)) ** 2).mean())
+    assert rmse(pred, truth) == pytest.approx(expected)
+
+
+def test_rmse_broadcast():
+    pred = [1., 2., 3.]
+    truth = [[1.], [2.], [4.]]
+    expected = np.sqrt(((np.asarray(pred) - np.asarray(truth)) ** 2).mean())
+    assert rmse(pred, truth) == pytest.approx(expected)
+
+
+def test_rmse_fail_shape():
+    pred = np.ones((2, 2))
+    truth = np.ones(3)
+    with pytest.raises(ValueError):
+        rmse(pred, truth)
+
+
+def test_pearson_and_spearman():
+    x = [[1., 2.], [2., 4.]]
+    y = [1., 3.]
+    r = pearson_r(x, y)
+    rho = spearman_r(x, y)
+    assert r == pytest.approx(1.)
+    assert rho == pytest.approx(1.)


### PR DESCRIPTION
Bug fix:
- RMSE function was actually calculating MAE
- Generated `MODELBOX_REGISTRY` etc is now cached in `~/.cache/duvida` by default, instead of package root (which might not be writable).

Improvements:
- Tests of evaluation functions
- Evaluation functions now reduce across ensemble dimension but check for broadcastability first
- Hyperopt utility now outputs the explicit configs under the `_ranges` key in JSON
- Hyperopt JSON key order now survives round-trip